### PR TITLE
Don't transform inline functions on html literals

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -87,6 +87,22 @@ module.exports = function(opts) {
   };
 
   const visitor = {
+    JSXOpeningElement(path) {
+      const nameNode = path.node.name;
+      if (
+        t.isJSXIdentifier(nameNode) &&
+        nameNode.name !== "this" &&
+        // isCompatTag returns true if the input string is to be transformed to
+        // to a string (html literal) in the React.createElement call.
+        // https://github.com/babel/babel/blob/04d2c030be2ecbbcdfc664b6ef16ef5f23eb0b20/packages/babel-plugin-transform-react-jsx/src/index.js#L15
+        t.react.isCompatTag(nameNode.name)
+      ) {
+        // No need to transform inline functions on html literals since an html
+        // literal cannot be a pure component.
+        path.skip();
+      }
+    },
+
     JSXExpressionContainer(path) {
       const exprPath = path.get("expression");
       if (t.isIdentifier(exprPath)) {

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -19,7 +19,7 @@ import { babelBind as _testBind } from \\"../../src\\";
   const hoistable = _testBind2(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return _testBind(hoistable, null, 1)();
 })();"
@@ -44,7 +44,7 @@ const _testBind = require(\\"../../src\\").babelBind;
   const hoistable = _testBind2(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return _testBind(hoistable, null, 1)();
 })();"
@@ -65,7 +65,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable.bind(null, 1).bind(null, 2).bind(null, 3)();
 })();"
@@ -92,7 +92,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, prop);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable({ a: { b: 10 } });
 })();"
@@ -137,7 +137,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, fn);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   function fn() {}
 })();"
@@ -153,7 +153,7 @@ import * as React from \\"react\\";
   const a = 2;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();"
@@ -175,7 +175,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, a);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(2, 3);
 })();"
@@ -186,12 +186,12 @@ exports[`reflective-bind babel transform arrowInlineJsxContainerElement.jsx 1`] 
 
 import { babelBind as _testBind } from \\"../../src\\";
 
-function _testBBHoisted2() {
-  <div />;
+function _testBBHoisted2(React) {
+  <React.Component />;
 }
 
-function _testBBHoisted() {
-  <div onClick={_testBind(_testBBHoisted2, this)} />;
+function _testBBHoisted(React) {
+  <React.Component onClick={_testBind(_testBBHoisted2, this, React)} />;
 }
 
 import * as React from \\"react\\";
@@ -199,7 +199,7 @@ import * as React from \\"react\\";
 (function () {
   // Inline arrow fn in JSXExpressionContainer should be hoisted.
   // Nested arrow fn should also be hoisted.
-  <div onClick={_testBind(_testBBHoisted, this)} />;
+  <React.Component onClick={_testBind(_testBBHoisted, this, React)} />;
 })();"
 `;
 
@@ -219,12 +219,12 @@ import * as React from \\"react\\";
 (function () {
   const Component = props => {};
 
-  // Should add \`Component\` as a parameter to the hoisted function, but not
-  // \`div\`.
+  // Should add \`HoistedIdentifier\` as a parameter to the hoisted function, but
+  // not \`div\`.
   const hoistable = _testBind(_testBBHoisted, this, Component);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 })();"
 `;
 
@@ -249,7 +249,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, Component);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 })();"
 `;
 
@@ -273,7 +273,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable({ a: { b: 10 } });
 })();"
@@ -299,7 +299,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, a);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(2)(4);
 })();"
@@ -310,10 +310,10 @@ exports[`reflective-bind babel transform arrowNestedHoistDeep.jsx 1`] = `
 
 import { babelBind as _testBind } from \\"../../src\\";
 
-function _testBBHoisted2(a, b) {
+function _testBBHoisted2(a, React, b) {
   let c = 3;
   const nestedHoistable = _testBind(_testBBHoisted, this, a, b, c);
-  return <div onClick={nestedHoistable} />;
+  return <React.Component onClick={nestedHoistable} />;
 }
 
 function _testBBHoisted(a, b, c, d) {
@@ -325,10 +325,10 @@ import * as React from \\"react\\";
 (function () {
   let a = 1;
 
-  const hoistable = _testBind(_testBBHoisted2, this, a);
+  const hoistable = _testBind(_testBBHoisted2, this, a, React);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 })();"
 `;
 
@@ -353,7 +353,7 @@ import * as React from \\"react\\";
     return items.map(item => {
       const hoistable = _testBind(_testBBHoisted, this, item);
       // Use in JSXExpressionContainer to enable hoisting
-      return <div onClick={hoistable} />;
+      return <React.Component onClick={hoistable} />;
     });
   };
 
@@ -383,7 +383,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable();
 })();"
@@ -404,7 +404,7 @@ import * as React from \\"react\\";
     const a = 2;
 
     // Use in JSXExpressionContainer to enable hoisting
-    <div onClick={shouldNotHoist} />;
+    <React.Component onClick={shouldNotHoist} />;
 
     return shouldNotHoist();
   }
@@ -435,7 +435,7 @@ import * as React from \\"react\\";
   a = 10;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();"
@@ -466,7 +466,7 @@ import * as React from \\"react\\";
   }
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();"
@@ -491,7 +491,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, a);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable();
 })();"
@@ -520,7 +520,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, a);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable();
 })();"
@@ -542,7 +542,7 @@ import * as React from \\"react\\";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();"
@@ -563,7 +563,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(1, 2, 3)(4);
 })();"
@@ -587,7 +587,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, a);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(3, 4);
 })();"
@@ -610,7 +610,7 @@ import React from \\"react\\";
 function MyComponent(props: { nested: { callback: () => void } }) {
   const hoistable = _testBind(_testBBHoisted, this, props);
 
-  return <div onClick={hoistable} />;
+  return <React.Component onClick={hoistable} />;
 }"
 `;
 
@@ -658,7 +658,7 @@ import React from \\"react\\";
       const hoistable = _testBind(_testBBHoisted, this, outerScopeVar);
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     shouldNotHoist: { val: 1 }
   };
@@ -692,7 +692,7 @@ import React from \\"react\\";
       const hoistable = _testBind(_testBBHoisted, this, this.props.fn, this.props.nested);
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     props: {
       fn: () => {},
@@ -764,7 +764,7 @@ import React from \\"react\\";
       const hoistable = _testBind(_testBBHoisted, this, outerScopeVar, this.props, this.props.val, this.props.nested);
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     props: {
       val: 1,
@@ -831,7 +831,7 @@ import React from \\"react\\";
       const hoistable = _testBind(_testBBHoisted, this, outerScopeVar, this.state, this.state.val, this.state.nested);
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     state: {
       val: 1,
@@ -853,7 +853,7 @@ import * as React from \\"react\\";
 const hoistable = _testBind(_testBBHoisted, this);
 
 // Use in JSXExpressionContainer to enable hoisting
-<div onClick={hoistable} />;"
+<React.Component onClick={hoistable} />;"
 `;
 
 exports[`reflective-bind babel transform arrowWithFlow.jsx 1`] = `
@@ -877,7 +877,7 @@ import * as React from \\"react\\";
   const hoistable = _testBind(_testBBHoisted, this, a);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(3, 4);
 })();"
@@ -899,7 +899,7 @@ import * as React from \\"react\\";
   const bindable = _testBind(test, null, 1, 2);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={bindable} />;
+  <React.Component onClick={bindable} />;
 
   return bindable();
 })();"
@@ -915,7 +915,7 @@ import * as React from \\"react\\";
   function foo() {}
 
   // Inline bind in JSXExpressionContainer should be converted.
-  <div onClick={_testBind(foo, this)} />;
+  <React.Component onClick={_testBind(foo, this)} />;
 })();"
 `;
 
@@ -937,7 +937,7 @@ import * as React from \\"react\\";
   const bindable = _testBind(test, null);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={bindable} />;
+  <React.Component onClick={bindable} />;
 
   return bindable;
 })();"
@@ -958,7 +958,7 @@ import React from \\"react\\";
   const bindable = _testBind(test, null, 1, 2);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={bindable} />;
+  <React.Component onClick={bindable} />;
 
   return bindable();
 })();"
@@ -996,7 +996,7 @@ import * as React from \\"react\\";
     const hoistable = _testBind(_testBBHoisted, this, a);
 
     // Use in JSXExpressionContainer to enable hoisting
-    <div onClick={hoistable} />;
+    <React.Component onClick={hoistable} />;
   }
 })();"
 `;
@@ -1017,7 +1017,7 @@ import * as React from \\"react\\";
   const hoistMeWithoutFlowIdentifiers = _testBind(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistMeWithoutFlowIdentifiers} />;
+  <React.Component onClick={hoistMeWithoutFlowIdentifiers} />;
 
   return hoistMeWithoutFlowIdentifiers();
 })();"
@@ -1042,7 +1042,23 @@ import * as React from \\"react\\";
   const hoistMeWithoutFlowIdentifiers = _testBind(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistMeWithoutFlowIdentifiers} />;
+  <React.Component onClick={hoistMeWithoutFlowIdentifiers} />;
+})();"
+`;
+
+exports[`reflective-bind babel transform jsxHtmlLiteral.jsx 1`] = `
+"// @flow
+
+import * as React from \\"react\\";
+
+(function () {
+  // Should not hoist because the callback is attached to a html literal, and
+  // not a component.
+  const shouldNotHoist = () => {
+    return 1;
+  };
+
+  <div onClick={shouldNotHoist} />;
 })();"
 `;
 
@@ -1068,7 +1084,7 @@ import * as React from \\"react\\";
   const shouldNotHoist = () => {};
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 })();"
 `;
 
@@ -1100,7 +1116,7 @@ function foo() {}
   fn = _testBind(_testBBHoisted2, this, a);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={fn} />;
+  <React.Component onClick={fn} />;
 })();"
 `;
 
@@ -1113,7 +1129,7 @@ import * as React from \\"react\\";
   const shouldNotHoist = () => shouldNotHoist();
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 })();"
 `;
 
@@ -1152,7 +1168,7 @@ import * as React from \\"react\\";
           const hoistable = _testBind(_testBBHoisted, this, w);
 
           // Use in JSXExpressionContainer to enable hoisting
-          <div onClick={hoistable} />;
+          <React.Component onClick={hoistable} />;
 
           break;
         }
@@ -1179,7 +1195,7 @@ function foo() {}
   const fn = condition ? _testBind(foo, null) : _testBind(_testBBHoisted, this);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={fn} />;
+  <React.Component onClick={fn} />;
 })();"
 `;
 
@@ -1200,6 +1216,6 @@ function foo() {}
   const condition = true;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={condition ? _testBind(foo, null) : _testBind(_testBBHoisted, this)} />;
+  <React.Component onClick={condition ? _testBind(foo, null) : _testBind(_testBBHoisted, this)} />;
 })();"
 `;

--- a/tests/babel/fixtures/alreadyImported.jsx
+++ b/tests/babel/fixtures/alreadyImported.jsx
@@ -10,7 +10,7 @@ import {babelBind as _testBind} from "../../src";
   const hoistable = a => a;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return _testBind(hoistable, null, 1)();
 })();

--- a/tests/babel/fixtures/alreadyRequired.jsx
+++ b/tests/babel/fixtures/alreadyRequired.jsx
@@ -10,7 +10,7 @@ const _testBind = require("../../src").babelBind;
   const hoistable = a => a;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return _testBind(hoistable, null, 1)();
 })();

--- a/tests/babel/fixtures/arrowBind.jsx
+++ b/tests/babel/fixtures/arrowBind.jsx
@@ -6,7 +6,7 @@ import * as React from "react";
   const hoistable = (a, b, c) => a + b + c;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable
     .bind(null, 1)

--- a/tests/babel/fixtures/arrowComputedProperty.jsx
+++ b/tests/babel/fixtures/arrowComputedProperty.jsx
@@ -14,7 +14,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable({a: {b: 10}});
 })();

--- a/tests/babel/fixtures/arrowDeclareFnAfterFn.jsx
+++ b/tests/babel/fixtures/arrowDeclareFnAfterFn.jsx
@@ -8,7 +8,7 @@ import * as React from "react";
   const hoistable = () => fn;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   function fn() {}
 })();

--- a/tests/babel/fixtures/arrowDeclareVarAfterFn.jsx
+++ b/tests/babel/fixtures/arrowDeclareVarAfterFn.jsx
@@ -7,7 +7,7 @@ import * as React from "react";
   const a = 2;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();

--- a/tests/babel/fixtures/arrowExpressionBody.jsx
+++ b/tests/babel/fixtures/arrowExpressionBody.jsx
@@ -7,7 +7,7 @@ import * as React from "react";
   const hoistable = (b, c) => a + b + c;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(2, 3);
 })();

--- a/tests/babel/fixtures/arrowInlineJsxContainerElement.jsx
+++ b/tests/babel/fixtures/arrowInlineJsxContainerElement.jsx
@@ -5,11 +5,11 @@ import * as React from "react";
 (function() {
   // Inline arrow fn in JSXExpressionContainer should be hoisted.
   // Nested arrow fn should also be hoisted.
-  <div
+  <React.Component
     onClick={() => {
-      <div
+      <React.Component
         onClick={() => {
-          <div />;
+          <React.Component />;
         }}
       />;
     }}

--- a/tests/babel/fixtures/arrowJsxIdentifier.jsx
+++ b/tests/babel/fixtures/arrowJsxIdentifier.jsx
@@ -5,8 +5,8 @@ import * as React from "react";
 (function() {
   const Component = props => {};
 
-  // Should add `Component` as a parameter to the hoisted function, but not
-  // `div`.
+  // Should add `HoistedIdentifier` as a parameter to the hoisted function, but
+  // not `div`.
   const hoistable = () => {
     <Component>
       <div>1</div>
@@ -14,5 +14,5 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 })();

--- a/tests/babel/fixtures/arrowJsxMemberExpression.jsx
+++ b/tests/babel/fixtures/arrowJsxMemberExpression.jsx
@@ -14,5 +14,5 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 })();

--- a/tests/babel/fixtures/arrowMemberExpression.jsx
+++ b/tests/babel/fixtures/arrowMemberExpression.jsx
@@ -13,7 +13,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable({a: {b: 10}});
 })();

--- a/tests/babel/fixtures/arrowNested.jsx
+++ b/tests/babel/fixtures/arrowNested.jsx
@@ -13,7 +13,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(2)(4);
 })();

--- a/tests/babel/fixtures/arrowNestedHoistDeep.jsx
+++ b/tests/babel/fixtures/arrowNestedHoistDeep.jsx
@@ -8,9 +8,9 @@ import * as React from "react";
   const hoistable = b => {
     let c = 3;
     const nestedHoistable = d => a + b + c + d;
-    return <div onClick={nestedHoistable} />;
+    return <React.Component onClick={nestedHoistable} />;
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 })();

--- a/tests/babel/fixtures/arrowNestedHoistInner.jsx
+++ b/tests/babel/fixtures/arrowNestedHoistInner.jsx
@@ -12,7 +12,7 @@ import * as React from "react";
     return items.map(item => {
       const hoistable = () => item;
       // Use in JSXExpressionContainer to enable hoisting
-      return <div onClick={hoistable} />;
+      return <React.Component onClick={hoistable} />;
     });
   };
 

--- a/tests/babel/fixtures/arrowRedeclareVar.jsx
+++ b/tests/babel/fixtures/arrowRedeclareVar.jsx
@@ -13,7 +13,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable();
 })();

--- a/tests/babel/fixtures/arrowRedeclareVarAfterFn.jsx
+++ b/tests/babel/fixtures/arrowRedeclareVarAfterFn.jsx
@@ -12,7 +12,7 @@ import * as React from "react";
     const a = 2;
 
     // Use in JSXExpressionContainer to enable hoisting
-    <div onClick={shouldNotHoist} />;
+    <React.Component onClick={shouldNotHoist} />;
 
     return shouldNotHoist();
   }

--- a/tests/babel/fixtures/arrowReferenceLateAssignment.jsx
+++ b/tests/babel/fixtures/arrowReferenceLateAssignment.jsx
@@ -19,7 +19,7 @@ import * as React from "react";
   a = 10;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();

--- a/tests/babel/fixtures/arrowReferenceLateAssignmentDifferentScope.jsx
+++ b/tests/babel/fixtures/arrowReferenceLateAssignmentDifferentScope.jsx
@@ -22,7 +22,7 @@ import * as React from "react";
   }
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();

--- a/tests/babel/fixtures/arrowReferenceOkAssignment.jsx
+++ b/tests/babel/fixtures/arrowReferenceOkAssignment.jsx
@@ -12,7 +12,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable();
 })();

--- a/tests/babel/fixtures/arrowReferenceOkAssignmentDifferentScope.jsx
+++ b/tests/babel/fixtures/arrowReferenceOkAssignmentDifferentScope.jsx
@@ -16,7 +16,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable();
 })();

--- a/tests/babel/fixtures/arrowReferenceReassignmentInFn.jsx
+++ b/tests/babel/fixtures/arrowReferenceReassignmentInFn.jsx
@@ -13,7 +13,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 
   return shouldNotHoist();
 })();

--- a/tests/babel/fixtures/arrowRestSpread.jsx
+++ b/tests/babel/fixtures/arrowRestSpread.jsx
@@ -8,7 +8,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(1, 2, 3)(4);
 })();

--- a/tests/babel/fixtures/arrowSimple.jsx
+++ b/tests/babel/fixtures/arrowSimple.jsx
@@ -11,7 +11,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(3, 4);
 })();

--- a/tests/babel/fixtures/arrowStatelessComponentProps.jsx
+++ b/tests/babel/fixtures/arrowStatelessComponentProps.jsx
@@ -10,5 +10,5 @@ function MyComponent(props: {nested: {callback: () => void}}) {
     props.nested.callback();
   };
 
-  return <div onClick={hoistable} />;
+  return <React.Component onClick={hoistable} />;
 }

--- a/tests/babel/fixtures/arrowThis.jsx
+++ b/tests/babel/fixtures/arrowThis.jsx
@@ -37,7 +37,7 @@ import React from "react";
       };
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     shouldNotHoist: {val: 1},
   };

--- a/tests/babel/fixtures/arrowThisCallExpression.jsx
+++ b/tests/babel/fixtures/arrowThisCallExpression.jsx
@@ -20,7 +20,7 @@ import React from "react";
       };
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     props: {
       fn: () => {},

--- a/tests/babel/fixtures/arrowThisProps.jsx
+++ b/tests/babel/fixtures/arrowThisProps.jsx
@@ -50,7 +50,7 @@ import React from "react";
       };
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     props: {
       val: 1,

--- a/tests/babel/fixtures/arrowThisState.jsx
+++ b/tests/babel/fixtures/arrowThisState.jsx
@@ -50,7 +50,7 @@ import React from "react";
       };
 
       // Use in JSXExpressionContainer to enable hoisting
-      <div onClick={hoistable} />;
+      <React.Component onClick={hoistable} />;
     },
     state: {
       val: 1,

--- a/tests/babel/fixtures/arrowTopLevel.jsx
+++ b/tests/babel/fixtures/arrowTopLevel.jsx
@@ -5,4 +5,4 @@ import * as React from "react";
 const hoistable = () => {};
 
 // Use in JSXExpressionContainer to enable hoisting
-<div onClick={hoistable} />;
+<React.Component onClick={hoistable} />;

--- a/tests/babel/fixtures/arrowWithFlow.jsx
+++ b/tests/babel/fixtures/arrowWithFlow.jsx
@@ -14,7 +14,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistable} />;
+  <React.Component onClick={hoistable} />;
 
   return hoistable(3, 4);
 })();

--- a/tests/babel/fixtures/bindFlow.jsx
+++ b/tests/babel/fixtures/bindFlow.jsx
@@ -12,7 +12,7 @@ import * as React from "react";
   const bindable = test.bind(null, 1, 2);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={bindable} />;
+  <React.Component onClick={bindable} />;
 
   return bindable();
 })();

--- a/tests/babel/fixtures/bindInlineJsxContainerElement.jsx
+++ b/tests/babel/fixtures/bindInlineJsxContainerElement.jsx
@@ -6,5 +6,5 @@ import * as React from "react";
   function foo() {}
 
   // Inline bind in JSXExpressionContainer should be converted.
-  <div onClick={foo.bind(this)} />;
+  <React.Component onClick={foo.bind(this)} />;
 })();

--- a/tests/babel/fixtures/bindNonFunction.jsx
+++ b/tests/babel/fixtures/bindNonFunction.jsx
@@ -14,7 +14,7 @@ import * as React from "react";
   const bindable = test.bind(null);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={bindable} />;
+  <React.Component onClick={bindable} />;
 
   return bindable;
 })();

--- a/tests/babel/fixtures/bindSimple.jsx
+++ b/tests/babel/fixtures/bindSimple.jsx
@@ -11,7 +11,7 @@ import React from "react";
   const bindable = test.bind(null, 1, 2);
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={bindable} />;
+  <React.Component onClick={bindable} />;
 
   return bindable();
 })();

--- a/tests/babel/fixtures/bindingNodeLocNPE.jsx
+++ b/tests/babel/fixtures/bindingNodeLocNPE.jsx
@@ -25,6 +25,6 @@ import * as React from "react";
     };
 
     // Use in JSXExpressionContainer to enable hoisting
-    <div onClick={hoistable} />;
+    <React.Component onClick={hoistable} />;
   }
 })();

--- a/tests/babel/fixtures/flowGenerics.jsx
+++ b/tests/babel/fixtures/flowGenerics.jsx
@@ -9,7 +9,7 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistMeWithoutFlowIdentifiers} />;
+  <React.Component onClick={hoistMeWithoutFlowIdentifiers} />;
 
   return hoistMeWithoutFlowIdentifiers();
 })();

--- a/tests/babel/fixtures/flowObjMap.jsx
+++ b/tests/babel/fixtures/flowObjMap.jsx
@@ -17,5 +17,5 @@ import * as React from "react";
   };
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={hoistMeWithoutFlowIdentifiers} />;
+  <React.Component onClick={hoistMeWithoutFlowIdentifiers} />;
 })();

--- a/tests/babel/fixtures/jsxHtmlLiteral.jsx
+++ b/tests/babel/fixtures/jsxHtmlLiteral.jsx
@@ -1,0 +1,13 @@
+// @flow
+
+import * as React from "react";
+
+(function() {
+  // Should not hoist because the callback is attached to a html literal, and
+  // not a component.
+  const shouldNotHoist = () => {
+    return 1;
+  };
+
+  <div onClick={shouldNotHoist} />;
+})();

--- a/tests/babel/fixtures/noTransform.jsx
+++ b/tests/babel/fixtures/noTransform.jsx
@@ -8,5 +8,5 @@ import * as React from "react";
   const shouldNotHoist = () => {};
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 })();

--- a/tests/babel/fixtures/reassignIdentifier.jsx
+++ b/tests/babel/fixtures/reassignIdentifier.jsx
@@ -15,5 +15,5 @@ function foo() {}
   fn = () => a;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={fn} />;
+  <React.Component onClick={fn} />;
 })();

--- a/tests/babel/fixtures/recursive.jsx
+++ b/tests/babel/fixtures/recursive.jsx
@@ -6,5 +6,5 @@ import * as React from "react";
   const shouldNotHoist = () => shouldNotHoist();
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={shouldNotHoist} />;
+  <React.Component onClick={shouldNotHoist} />;
 })();

--- a/tests/babel/fixtures/renameIdentifier.jsx
+++ b/tests/babel/fixtures/renameIdentifier.jsx
@@ -24,7 +24,7 @@ import * as React from "react";
         const hoistable = () => w;
 
         // Use in JSXExpressionContainer to enable hoisting
-        <div onClick={hoistable} />;
+        <React.Component onClick={hoistable} />;
 
         break;
       }

--- a/tests/babel/fixtures/ternaryExpression.jsx
+++ b/tests/babel/fixtures/ternaryExpression.jsx
@@ -9,5 +9,5 @@ function foo() {}
   const fn = condition ? foo.bind(null) : () => 1;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={fn} />;
+  <React.Component onClick={fn} />;
 })();

--- a/tests/babel/fixtures/ternaryExpressionInline.jsx
+++ b/tests/babel/fixtures/ternaryExpressionInline.jsx
@@ -8,5 +8,5 @@ function foo() {}
   const condition = true;
 
   // Use in JSXExpressionContainer to enable hoisting
-  <div onClick={condition ? foo.bind(null) : () => 1} />;
+  <React.Component onClick={condition ? foo.bind(null) : () => 1} />;
 })();

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -112,6 +112,7 @@ const EVAL_RESULTS = {
   "fnSimple.jsx": 4,
   "fnTopLevel.jsx": undefined,
   "fnWithFlow.jsx": 4,
+  "jsxHtmlLiteral.jsx": undefined,
   "mapArrow.jsx": undefined,
   "noTransform.jsx": undefined,
   "reassignIdentifier.jsx": undefined,


### PR DESCRIPTION
HTML literals are not components (`<div>`, `<button>`, etc) and transforming arrow functions here don't give you any performance gains.

https://github.com/flexport/reflective-bind/issues/7

I changed all the `div` references in the fixtures that were there to enable transformations to `React.Component`. The updated snapshots look fine after the change. The only changes were the rename, and hoisting the `React` identifier when needed.