### PR TITLE
Small refactoring

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -206,7 +206,7 @@ module.exports = function(opts) {
     ThisExpression(path, state) {
       // Only allow hoisting if `this` refers to the same `this` as the arrow
       // function we want to hoist.
-      if (!sameThisContext(state.fnPath, path)) {
+      if (!isDefinitelySameThisContext(state.fnPath, path)) {
         return;
       }
 
@@ -483,7 +483,7 @@ module.exports = function(opts) {
    * This means that the function-ancestor chain must only consist of arrow
    * functions.
    */
-  function sameThisContext(parentFnPath, path) {
+  function isDefinitelySameThisContext(parentFnPath, path) {
     let cur = path.getFunctionParent();
     while (cur) {
       if (cur === parentFnPath) {

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -425,10 +425,12 @@ import * as React from \\"react\\";
   // Should not hoist because it references a variable that is assigned after.
   const shouldNotHoist = () => {
     // Reference the non-constant identifier first.
-    alert(a);
+    a;
+
     // Reference a constant identifier next.
     // Make sure we don't hoist even if we reference a constant.
-    alert(c);
+    c;
+
     return a;
   };
 
@@ -453,10 +455,12 @@ import * as React from \\"react\\";
   // Should not hoist because it references a variable that is assigned after.
   const shouldNotHoist = () => {
     // Reference the non-constant identifier first.
-    alert(a);
+    a;
+
     // Reference a constant identifier next.
     // Make sure we don't hoist even if we reference a constant.
-    alert(c);
+    c;
+
     return a;
   };
 

--- a/tests/babel/fixtures/arrowReferenceLateAssignment.jsx
+++ b/tests/babel/fixtures/arrowReferenceLateAssignment.jsx
@@ -9,10 +9,12 @@ import * as React from "react";
   // Should not hoist because it references a variable that is assigned after.
   const shouldNotHoist = () => {
     // Reference the non-constant identifier first.
-    alert(a);
+    a;
+
     // Reference a constant identifier next.
     // Make sure we don't hoist even if we reference a constant.
-    alert(c);
+    c;
+
     return a;
   };
 

--- a/tests/babel/fixtures/arrowReferenceLateAssignmentDifferentScope.jsx
+++ b/tests/babel/fixtures/arrowReferenceLateAssignmentDifferentScope.jsx
@@ -9,10 +9,12 @@ import * as React from "react";
   // Should not hoist because it references a variable that is assigned after.
   const shouldNotHoist = () => {
     // Reference the non-constant identifier first.
-    alert(a);
+    a;
+
     // Reference a constant identifier next.
     // Make sure we don't hoist even if we reference a constant.
-    alert(c);
+    c;
+
     return a;
   };
 


### PR DESCRIPTION
Two small changes in two commits
- Rename `sameThisContext` to `isDefinitelySameThisContext`.
- Remove the call to `alert` in the test fixtures. These calls don't add any value to the test and can cause issues if they are executed.