### PR TITLE
Don't transform ref callbacks

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -103,6 +103,13 @@ module.exports = function(opts) {
       }
     },
 
+    JSXAttribute(path) {
+      // Don't transform ref callbacks
+      if (t.isJSXIdentifier(path.node.name) && path.node.name.name === "ref") {
+        path.skip();
+      }
+    },
+
     JSXExpressionContainer(path) {
       const exprPath = path.get("expression");
       if (t.isIdentifier(exprPath)) {

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -1133,6 +1133,20 @@ import * as React from \\"react\\";
 })();"
 `;
 
+exports[`reflective-bind babel transform refCallback.jsx 1`] = `
+"// @flow
+
+import * as React from \\"react\\";
+
+(function () {
+  // Should not hoist callbacks attached to the \`ref\` prop.
+  const shouldNotHoist = e => {};
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component ref={shouldNotHoist} />;
+})();"
+`;
+
 exports[`reflective-bind babel transform renameIdentifier.jsx 1`] = `
 "// @flow
 

--- a/tests/babel/fixtures/refCallback.jsx
+++ b/tests/babel/fixtures/refCallback.jsx
@@ -1,0 +1,11 @@
+// @flow
+
+import * as React from "react";
+
+(function() {
+  // Should not hoist callbacks attached to the `ref` prop.
+  const shouldNotHoist = e => {};
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component ref={shouldNotHoist} />;
+})();

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -117,6 +117,7 @@ const EVAL_RESULTS = {
   "noTransform.jsx": undefined,
   "reassignIdentifier.jsx": undefined,
   "recursive.jsx": undefined,
+  "refCallback.jsx": undefined,
   "renameIdentifier.jsx": undefined,
   "ternaryExpression.jsx": undefined,
   "ternaryExpressionInline.jsx": undefined,


### PR DESCRIPTION
In React, the `ref` prop is not passed to the child component and thus any callbacks passed to it does not need to be transformed.

https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element