### PR TITLE
Don't hoist top level arrow functions

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -155,6 +155,13 @@ module.exports = function(opts) {
   }
 
   function processArrowFunctionExpression(path) {
+    // Don't hoist if the arrow function is top level (defined in the same
+    // scope as the hoist path) since that is where it's going to be hoisted
+    // to anyways.
+    if (path.parentPath.scope === _hoistPath.scope) {
+      return;
+    }
+
     const state = {
       fnPath: path,
       canHoist: true,

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -846,14 +846,27 @@ exports[`reflective-bind babel transform arrowTopLevel.jsx 1`] = `
 
 import { babelBind as _testBind } from \\"../../src\\";
 
-function _testBBHoisted() {}
+function _testBBHoisted(a) {
+  return a;
+}
 
 import * as React from \\"react\\";
 
-const hoistable = _testBind(_testBBHoisted, this);
+// Should not hoist because arrow function is already at the top level.
+const shouldNotHoist = a => {
+  return a;
+};
+
+{
+  // Hoistable because it is in a different scope than the top level.
+  const hoistable = _testBind(_testBBHoisted, this);
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={hoistable} />;
+}
 
 // Use in JSXExpressionContainer to enable hoisting
-<React.Component onClick={hoistable} />;"
+<React.Component onClick={shouldNotHoist} />;"
 `;
 
 exports[`reflective-bind babel transform arrowWithFlow.jsx 1`] = `

--- a/tests/babel/fixtures/arrowTopLevel.jsx
+++ b/tests/babel/fixtures/arrowTopLevel.jsx
@@ -2,7 +2,20 @@
 
 import * as React from "react";
 
-const hoistable = () => {};
+// Should not hoist because arrow function is already at the top level.
+const shouldNotHoist = a => {
+  return a;
+};
+
+{
+  // Hoistable because it is in a different scope than the top level.
+  const hoistable = a => {
+    return a;
+  };
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={hoistable} />;
+}
 
 // Use in JSXExpressionContainer to enable hoisting
-<React.Component onClick={hoistable} />;
+<React.Component onClick={shouldNotHoist} />;


### PR DESCRIPTION
When we transform arrow function callbacks we hoist them to the `Program` path. If an arrow function is already defined in the same scope where it will be hoisted, there is no point hoisting the arrow function.