### PR TITLE
Don't transform `fn[bind](...)`

### DIFF
--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -900,6 +900,25 @@ import * as React from \\"react\\";
 })();"
 `;
 
+exports[`reflective-bind babel transform bindComputed.jsx 1`] = `
+"// @flow
+
+import React from \\"react\\";
+
+(function () {
+  function test(a, b) {
+    return a + b;
+  }
+
+  const bind = \\"bind\\";
+  // Should not transform because \`test[bind]\` is a computed MemberExpression
+  const shouldNotTransform = test[bind](null, 1, 2);
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={shouldNotTransform} />;
+})();"
+`;
+
 exports[`reflective-bind babel transform bindFlow.jsx 1`] = `
 "// @flow
 

--- a/tests/babel/fixtures/bindComputed.jsx
+++ b/tests/babel/fixtures/bindComputed.jsx
@@ -1,0 +1,16 @@
+// @flow
+
+import React from "react";
+
+(function() {
+  function test(a, b) {
+    return a + b;
+  }
+
+  const bind = "bind";
+  // Should not transform because `test[bind]` is a computed MemberExpression
+  const shouldNotTransform = test[bind](null, 1, 2);
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={shouldNotTransform} />;
+})();

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -93,6 +93,7 @@ const EVAL_RESULTS = {
   "arrowThisState.jsx": undefined,
   "arrowTopLevel.jsx": undefined,
   "arrowWithFlow.jsx": 10,
+  "bindComputed.jsx": undefined,
   "bindFlow.jsx": 3,
   "bindInlineJsxContainerElement.jsx": undefined,
   "bindNonFunction.jsx": 99,


### PR DESCRIPTION
`bind` could have any value, so we could be calling any method on `fn`.

We only want to transform `fn.bind(...)`