### PR TITLE
Fix error where functions are hoisted with function mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* Don't transform functions referencing a variable that is re-assigned in a
+  different function.
+
 ## 0.0.4-rc1
 
-- Don't transform inline functions on `ref` prop.
-- Don't transform arrow functions defined at the top level.
+* Don't transform inline functions on `ref` prop.
+* Don't transform arrow functions defined at the top level.
 
 ## 0.0.3
 
-- Support non-constant reference in arrow function as long as there is no reassignment to the variable after the arrow function.
-- Don't transform inline functions on JSX html literals.
+* Support non-constant reference in arrow function as long as there is no
+  reassignment to the variable after the arrow function.
+* Don't transform inline functions on JSX html literals.
 
 ## 0.0.2
 

--- a/babel/index.js
+++ b/babel/index.js
@@ -435,12 +435,10 @@ module.exports = function(opts) {
       );
     }
 
-    // If the check path is inside a function, it may be called after
+    // If the checkPath is inside a function, it might be called after
+    // otherPath has executed.
     for (let i = 1; i < checkPathAncestorIdx; i++) {
-      if (
-        t.isArrowFunctionExpression(checkPathAncestry[i]) ||
-        t.isFunctionDeclaration(checkPathAncestry[i])
-      ) {
+      if (t.isFunction(checkPathAncestry[i])) {
         return false;
       }
     }

--- a/babel/index.js
+++ b/babel/index.js
@@ -17,8 +17,8 @@
  *     we would either get a reference error, or we would bind to the wrong
  *     value.
  *   - Bail if the function closes over a variable that is bound after it.
- *     Since we replace the function call with a call to `babelBind` and pass 
- *     in the closed over variables, it would result in an reference error. 
+ *     Since we replace the function call with a call to `babelBind` and pass
+ *     in the closed over variables, it would result in an reference error.
  *   - Otherwise, hoist the arrow function to module level function and replace
  *     the arrow function with: `babelBind(hoisted, this, ...constants)`,
  *     where `constants` is a list of all the constant variables that the
@@ -435,6 +435,16 @@ module.exports = function(opts) {
       );
     }
 
+    // If the check path is inside a function, it may be called after
+    for (let i = 1; i < checkPathAncestorIdx; i++) {
+      if (
+        t.isArrowFunctionExpression(checkPathAncestry[i]) ||
+        t.isFunctionDeclaration(checkPathAncestry[i])
+      ) {
+        return false;
+      }
+    }
+
     // If both relationshps are part of a container list, the key property
     // gives you the index in the container.
     if (checkPathRelationship.listKey && otherPathRelationship.listKey) {
@@ -500,7 +510,7 @@ module.exports = function(opts) {
 
   /**
    * Returns true only if path has the same `this` context as parentPath.
-   * 
+   *
    * This means that the function-ancestor chain must only consist of arrow
    * functions.
    */

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -552,6 +552,48 @@ import * as React from \\"react\\";
 })();"
 `;
 
+exports[`reflective-bind babel transform arrowReferenceReassignmentInOtherArrowFn.jsx 1`] = `
+"// @flow
+
+import * as React from \\"react\\";
+
+(function () {
+  let a = null;
+  const other = () => {
+    a = 1;
+  };
+  const shouldNotHoist = () => a;
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={shouldNotHoist} />;
+
+  other();
+
+  return shouldNotHoist();
+})();"
+`;
+
+exports[`reflective-bind babel transform arrowReferenceReassignmentInOtherFn.jsx 1`] = `
+"// @flow
+
+import * as React from \\"react\\";
+
+(function () {
+  let a = null;
+  function other() {
+    a = 1;
+  }
+  const shouldNotHoist = () => a;
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={shouldNotHoist} />;
+
+  other();
+
+  return shouldNotHoist();
+})();"
+`;
+
 exports[`reflective-bind babel transform arrowRestSpread.jsx 1`] = `
 "// @flow
 

--- a/tests/babel/fixtures/arrowReferenceReassignmentInOtherArrowFn.jsx
+++ b/tests/babel/fixtures/arrowReferenceReassignmentInOtherArrowFn.jsx
@@ -1,0 +1,16 @@
+// @flow
+
+import * as React from "react";
+
+(function() {
+  let a = null;
+  const other = () => {a = 1};
+  const shouldNotHoist = () => a;
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={shouldNotHoist} />;
+
+  other();
+
+  return shouldNotHoist();
+})();

--- a/tests/babel/fixtures/arrowReferenceReassignmentInOtherFn.jsx
+++ b/tests/babel/fixtures/arrowReferenceReassignmentInOtherFn.jsx
@@ -1,0 +1,18 @@
+// @flow
+
+import * as React from "react";
+
+(function() {
+  let a = null;
+  function other() {
+    a = 1;
+  }
+  const shouldNotHoist = () => a;
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={shouldNotHoist} />;
+
+  other();
+
+  return shouldNotHoist();
+})();

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -82,6 +82,8 @@ const EVAL_RESULTS = {
   "arrowReferenceOkAssignment.jsx": 10,
   "arrowReferenceOkAssignmentDifferentScope.jsx": 10,
   "arrowReferenceReassignmentInFn.jsx": 10,
+  "arrowReferenceReassignmentInOtherArrowFn.jsx": 1,
+  "arrowReferenceReassignmentInOtherFn.jsx": 1,
   "arrowRedeclareVar.jsx": 2,
   "arrowRedeclareVarAfterFn.jsx": 2,
   "arrowRestSpread.jsx": 10,


### PR DESCRIPTION
If a function uses a variable that is mutated by another function, it shouldn't be hoisted even if the other function is defined before the function to be hoisted. See included test cases.