### PR TITLE
Add "propRegex" option to only transform matching prop names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Add "propRegex" option to only transform matching prop names.
+
 ## 0.0.4
+
 * Add "log" option to log general transform info and warnings.
 * Log info about which inline functions are transformed.
 * Log warnings about sub-optimial code and how to fix it.

--- a/babel/index.js
+++ b/babel/index.js
@@ -158,8 +158,6 @@ module.exports = function(opts) {
   };
 
   function shouldSkipProp(name) {
-    // - Skip "ref" props.
-    // - If _propRegexCompiled exists, skip props that don't match.
     return (
       name === "ref" || (_propRegexCompiled && !_propRegexCompiled.test(name))
     );

--- a/babel/index.js
+++ b/babel/index.js
@@ -47,7 +47,7 @@ const SKIP_RE = /^\/\/ @no-reflective-bind-babel$/m;
 module.exports = function(opts) {
   const t = opts.types;
 
-  let _propRegex;
+  let _propRegexCompiled;
   let _filename;
   let _hoistedSlug;
   let _bableBindIdentifer;
@@ -81,7 +81,8 @@ module.exports = function(opts) {
         return;
       }
       logger.setLevel(log);
-      _propRegex = propRegex != null ? new RegExp(propRegex) : undefined;
+      _propRegexCompiled =
+        propRegex != null ? new RegExp(propRegex) : undefined;
       _filename = file.opts.filename;
       _hoistPath = path;
       _hoistedSlug = hoistedSlug;
@@ -158,8 +159,10 @@ module.exports = function(opts) {
 
   function shouldSkipProp(name) {
     // - Skip "ref" props.
-    // - If _propRegex is provided, skip props that don't match.
-    return name === "ref" || (_propRegex && !_propRegex.test(name));
+    // - If _propRegexCompiled exists, skip props that don't match.
+    return (
+      name === "ref" || (_propRegexCompiled && !_propRegexCompiled.test(name))
+    );
   }
 
   function processPath(path, state) {

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -1124,6 +1124,37 @@ import * as React from \\"react\\";
 })();"
 `;
 
+exports[`reflective-bind babel transform ignorePropNameByRegex.jsx 1`] = `
+"// @flow
+
+import { babelBind as _testBind } from \\"../../src\\";
+
+function _testBBHoisted(a) {
+  return a;
+}
+
+import * as React from \\"react\\";
+
+(function () {
+  let a = 1;
+
+  // This function is used as a callback to the \`render\` prop.
+  // The index-test.js should be configured to only allow
+  // \`on[A-Z][A-Za-z]+\` prop names.
+  const shouldNotHoist = () => a;
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component render={shouldNotHoist} />;
+
+  // This function should still be hoisted because it is used
+  // as a callback to the \`onClick\` prop.
+  const hoistable = _testBind(_testBBHoisted, this, a);
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={hoistable} />;
+})();"
+`;
+
 exports[`reflective-bind babel transform jsxHtmlLiteral.jsx 1`] = `
 "// @flow
 

--- a/tests/babel/fixtures/ignorePropNameByRegex.jsx
+++ b/tests/babel/fixtures/ignorePropNameByRegex.jsx
@@ -1,0 +1,22 @@
+// @flow
+
+import * as React from "react";
+
+(function() {
+  let a = 1;
+
+  // This function is used as a callback to the `render` prop.
+  // The index-test.js should be configured to only allow
+  // `on[A-Z][A-Za-z]+` prop names.
+  const shouldNotHoist = () => a;
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component render={shouldNotHoist} />;
+
+  // This function should still be hoisted because it is used
+  // as a callback to the `onClick` prop.
+  const hoistable = () => a;
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={hoistable} />;
+})();

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -15,15 +15,14 @@ const BABEL_BIND_IDENTIFIER_NAME = "testBind";
 // Location of the main reflective-bind index file
 const INDEX_MODULE = "../../src";
 
-const TARGET_PLUGIN = [
-  plugin,
-  {
-    log: "debug",
-    hoistedSlug: HOISTED_SLUG,
-    babelBindSlug: BABEL_BIND_IDENTIFIER_NAME,
-    indexModule: INDEX_MODULE,
-  },
-];
+const PLUGIN_OPTS = {
+  log: "debug",
+  hoistedSlug: HOISTED_SLUG,
+  babelBindSlug: BABEL_BIND_IDENTIFIER_NAME,
+  indexModule: INDEX_MODULE,
+};
+
+const TARGET_PLUGIN = [plugin, PLUGIN_OPTS];
 
 const SNAPSHOT_TRANSFORM_OPTS = {
   babelrc: false,
@@ -57,7 +56,7 @@ describe("reflective-bind babel transform", () => {
       // looks like even if later assertions fail.
       const {code: snapshotCode} = transformFileSync(
         filePath,
-        SNAPSHOT_TRANSFORM_OPTS
+        CUSTOM_SNAPSHOT_OPTS[filename] || SNAPSHOT_TRANSFORM_OPTS
       );
       expect(snapshotCode).toMatchSnapshot();
 
@@ -144,6 +143,7 @@ const EVAL_RESULTS = {
   "fnSimple.jsx": 4,
   "fnTopLevel.jsx": undefined,
   "fnWithFlow.jsx": 4,
+  "ignorePropNameByRegex.jsx": undefined,
   "jsxHtmlLiteral.jsx": undefined,
   "mapArrow.jsx": undefined,
   "noTransform.jsx": undefined,
@@ -153,6 +153,21 @@ const EVAL_RESULTS = {
   "renameIdentifier.jsx": undefined,
   "ternaryExpression.jsx": undefined,
   "ternaryExpressionInline.jsx": undefined,
+};
+
+const CUSTOM_SNAPSHOT_OPTS = {
+  "ignorePropNameByRegex.jsx": {
+    ...SNAPSHOT_TRANSFORM_OPTS,
+    plugins: [
+      [
+        plugin,
+        {
+          ...PLUGIN_OPTS,
+          propRegex: "^on[A-Z].*$",
+        },
+      ],
+    ],
+  },
 };
 
 function validateResult(filename: string, code: string) {


### PR DESCRIPTION
This gives developers more control over which props are transformed. The main purpose is to use this to avoid transforming render callbacks.