### PR TITLE
nodesDefinitelyEqual: Handle case for adjacent StringLiterals nodes

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -566,6 +566,8 @@ module.exports = function(opts) {
         nodesDefinitelyEqual(node1.object, node2.object) &&
         nodesDefinitelyEqual(node1.property, node2.property)
       );
+    } else if (t.isStringLiteral(node1)) {
+      return node1.value === node2.value;
     } else {
       throw new Error(
         `Equality comparison not supported for node type "${node1.type}"`

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -716,7 +716,7 @@ exports[`reflective-bind babel transform arrowThisCallExpression.jsx 1`] = `
 
 import { babelBind as _testBind } from \\"../../src\\";
 
-function _testBBHoisted(_temp, _temp2) {
+function _testBBHoisted(_temp, _temp2, _temp3, _temp4) {
   // The entire \`this.props.fn\` should be hoisted because we don't
   // expect that \`fn\` cares about the \`props\` being its context.
   _temp();
@@ -728,6 +728,13 @@ function _testBBHoisted(_temp, _temp2) {
   // Only \`this.props.nested\` should be pulled out since we don't hoist
   // deep attribute accesses.
   _temp2.deepNested.deepNestedFn();
+
+  // The entire \`this.props[\\"string.key.fn\\"]\` should be hoisted because we don't
+  // expect that \`\\"string.key.fn\\"\` cares about the \`props\` being its context.
+  _temp3();
+
+  // Using a second string function shouldn't fail. It should behave as the previous.
+  _temp4();
 }
 
 import React from \\"react\\";
@@ -735,7 +742,7 @@ import React from \\"react\\";
 (function () {
   return {
     foo() {
-      const hoistable = _testBind(_testBBHoisted, this, this.props.fn, this.props.nested);
+      const hoistable = _testBind(_testBBHoisted, this, this.props.fn, this.props.nested, this.props[\\"string.key.fn\\"], this.props[\\"another.string.key.fn\\"]);
 
       // Use in JSXExpressionContainer to enable hoisting
       <React.Component onClick={hoistable} />;
@@ -747,7 +754,9 @@ import React from \\"react\\";
         deepNested: {
           deepNestedFn: () => {}
         }
-      }
+      },
+      \\"string.key.fn\\": () => {},
+      \\"another.string.key.fn\\": () => {}
     }
   };
 })();"

--- a/tests/babel/fixtures/arrowThisCallExpression.jsx
+++ b/tests/babel/fixtures/arrowThisCallExpression.jsx
@@ -17,6 +17,13 @@ import React from "react";
         // Only `this.props.nested` should be pulled out since we don't hoist
         // deep attribute accesses.
         this.props.nested.deepNested.deepNestedFn();
+
+        // The entire `this.props["string.key.fn"]` should be hoisted because we don't
+        // expect that `"string.key.fn"` cares about the `props` being its context.
+        this.props["string.key.fn"]();
+
+        // Using a second string function shouldn't fail. It should behave as the previous.
+        this.props["another.string.key.fn"]();
       };
 
       // Use in JSXExpressionContainer to enable hoisting
@@ -30,6 +37,8 @@ import React from "react";
           deepNestedFn: () => {},
         },
       },
+      "string.key.fn": () => {},
+      "another.string.key.fn": () => {},
     },
   };
 })();


### PR DESCRIPTION
I ran into the error in this method because I sometimes pass actions
from redux in like:
```
this.props["actions.action1"]();
this.props["actions.action2"]();
```

The code seemed to work fine with a single StringLiteral, but it failed
when I added a second.