### PR TITLE
Recommend monkey-patching Component to avoid warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ class MyComponent extends React.Component {
 }
 ```
 
-If you’re already using `React.PureComponent` and want to avoid updating all of your components, consider monkey patching `shouldComponentUpdate` 🙊
+If you want to avoid updating all of your components, consider monkey patching `shouldComponentUpdate` 🙊
 
 ```js
 import React from "react";
 import {shouldComponentUpdate} from "reflective-bind";
 
-React.PureComponent.prototype.shouldComponentUpdate = function(
+React.Component.prototype.shouldComponentUpdate = function(
   nextProps,
   nextState
 ) {


### PR DESCRIPTION
Hey there! I recently gave in and decided to try the monkey patch recommended in the README, only to find that React warns about implementing `shouldComponentUpdate` in `PureComponent`s and indeed doesn't seem, from what I could tell, to directly access it on that class in its internals. I found that monkey-patching `Component` itself both avoided the warnings and allowed React to actually call the patch function.

Forgive a massively minute quibble of a pull request, but I thought it might be useful for others too 😬. Thanks for all your work on this package!