### PR TITLE
Expose shallowReflectiveEqual function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,8 @@
 
 import babelBind from "./babelBind";
 import reflectiveBind, {reflectiveEqual, isReflective} from "./reflectiveBind";
+import shallowReflectiveEqual from "./shallowReflectiveEqual";
 import shouldComponentUpdate from "./shouldComponentUpdate";
 
 export default reflectiveBind;
-export {babelBind, reflectiveEqual, isReflective, shouldComponentUpdate};
+export {babelBind, reflectiveEqual, isReflective, shallowReflectiveEqual, shouldComponentUpdate};


### PR DESCRIPTION
because it is useful to implement customized shouldComponentUpdate functions.