### PR TITLE
Better handling of duplicate hoisted function arguments

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -559,6 +559,8 @@ module.exports = function(opts) {
       return true;
     } else if (t.isIdentifier(node1)) {
       return node1.name === node2.name;
+    } else if (t.isStringLiteral(node1)) {
+      return node1.value === node2.value;
     } else if (t.isMemberExpression(node1)) {
       return (
         node1.computed === node2.computed &&

--- a/babel/index.js
+++ b/babel/index.js
@@ -3,9 +3,8 @@
  * function expressions and arrow functions when possible to remove function
  * copying.
  *
- * Technically we only need to do this for code relevant to React render.
- * However, for completeness and simplicity, we just apply to all places
- * in the code. This can be changed in the future.
+ * We only do this for code relevant to React render to minimize the
+ * processing time and code bloat.
  *
  * Function.prototype.bind:
  *   - Simply replace `expression.bind(...bindArgs)` with

--- a/babel/index.js
+++ b/babel/index.js
@@ -568,9 +568,7 @@ module.exports = function(opts) {
         nodesDefinitelyEqual(node1.property, node2.property)
       );
     } else {
-      throw new Error(
-        `Equality comparison not supported for node type "${node1.type}"`
-      );
+      return false;
     }
   }
 

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -77,17 +77,20 @@ exports[`reflective-bind babel transform arrowComputedProperty.jsx 1`] = `
 import { babelBind as _testBind } from \\"../../src\\";
 
 function _testBBHoisted(prop, obj) {
-  return obj.a[prop];
+  return obj[prop].b;
 }
 
 import * as React from \\"react\\";
 
 (function () {
+  // These dummy variables exist to make sure we don't use the wrong variables
+  // when hoisting.
   // eslint-disable-next-line no-unused-vars
   let a = 1;
   // eslint-disable-next-line no-unused-vars
   let b = 2;
-  let prop = \\"b\\";
+
+  let prop = \\"a\\";
 
   const hoistable = _testBind(_testBBHoisted, this, prop);
 

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -1107,6 +1107,29 @@ import * as React from \\"react\\";
 })();"
 `;
 
+exports[`reflective-bind babel transform duplicateComputedMemberExpressionStringArg.jsx 1`] = `
+"// @flow
+
+import { babelBind as _testBind } from \\"../../src\\";
+
+function _testBBHoisted(_temp) {
+  // There should only be one parameter in the hoisted function
+  _temp;
+  _temp;
+}
+
+import React from \\"react\\";
+
+class MyComponent extends React.Component<{| a: number |}> {
+  render() {
+    const hoistable = _testBind(_testBBHoisted, this, this.props[\\"a\\"]);
+
+    // Use in JSXExpressionContainer to enable hoisting
+    return <React.Component onClick={hoistable} />;
+  }
+}"
+`;
+
 exports[`reflective-bind babel transform flowGenerics.jsx 1`] = `
 "// @flow
 

--- a/tests/babel/fixtures/arrowComputedProperty.jsx
+++ b/tests/babel/fixtures/arrowComputedProperty.jsx
@@ -3,14 +3,17 @@
 import * as React from "react";
 
 (function() {
+  // These dummy variables exist to make sure we don't use the wrong variables
+  // when hoisting.
   // eslint-disable-next-line no-unused-vars
   let a = 1;
   // eslint-disable-next-line no-unused-vars
   let b = 2;
-  let prop = "b";
+
+  let prop = "a";
 
   const hoistable = obj => {
-    return obj.a[prop];
+    return obj[prop].b;
   };
 
   // Use in JSXExpressionContainer to enable hoisting

--- a/tests/babel/fixtures/duplicateComputedMemberExpressionStringArg.jsx
+++ b/tests/babel/fixtures/duplicateComputedMemberExpressionStringArg.jsx
@@ -1,0 +1,16 @@
+// @flow
+
+import React from "react";
+
+class MyComponent extends React.Component<{|a: number|}> {
+  render() {
+    const hoistable = () => {
+      // There should only be one parameter in the hoisted function
+      this.props["a"];
+      this.props["a"];
+    };
+
+    // Use in JSXExpressionContainer to enable hoisting
+    return <React.Component onClick={hoistable} />;
+  }
+}

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -130,6 +130,7 @@ const EVAL_RESULTS = {
   "bindSimple.jsx": 3,
   "bindingNodeLocNPE.jsx": undefined,
   "classReference.jsx": undefined,
+  "duplicateComputedMemberExpressionStringArg.jsx": undefined,
   "flowGenerics.jsx": 6,
   "flowObjMap.jsx": undefined,
   "fnAsync.jsx": undefined,


### PR DESCRIPTION
**Best reviewed 1 commit at a time**

- Support deduping of hoisted function arguments of the form `this.props["foo"]`
- Change `nodesDefinitelyEqual` to return `false` instead of throw error on unrecognized node types. The error was originally included to make sure we caught most basic usages. All this does is if a node type is not supported, it will be deduped in the hoisted function parameters.