### PR TITLE
Fix hanging identifiers when lodash plugin is applied after

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -105,6 +105,10 @@ module.exports = function(opts) {
         logger.debug(
           `Total inline functions transformed: ${_totalTransformedInAllFiles}`
         );
+
+        // Have babel update all references after hoisting.
+        // There's probably a more efficient way to do this.
+        path.scope.crawl();
       }
     },
   };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "babel-cli": "6.26.0",
     "babel-eslint": "8.0.0",
+    "babel-plugin-lodash": "3.3.4",
     "babel-plugin-transform-flow-comments": "6.22.0",
     "babel-preset-env": "1.6.0",
     "babel-preset-react": "6.24.1",

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -1222,6 +1222,32 @@ import * as React from \\"react\\";
 })();"
 `;
 
+exports[`reflective-bind babel transform lodashBabelPlugin.jsx 1`] = `
+"import _intersection from \\"lodash/intersection\\";
+// @flow
+
+import { babelBind as _testBind } from \\"../../src\\";
+
+function _testBBHoisted(intersection, c, d) {
+  // After hoisting, this should reference the \`intersection\` function param
+  intersection([], []);
+}
+
+import * as React from \\"react\\";
+
+
+(function () {
+  let a = 1;
+
+  // After hoisting, the hoisted function should be called with the transformed
+  // lodash import (i.e. \`_intersection\`)
+  const hoistable = _testBind(_testBBHoisted, this, _intersection);
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={hoistable} />;
+})();"
+`;
+
 exports[`reflective-bind babel transform mapArrow.jsx 1`] = `
 "// @flow
 

--- a/tests/babel/fixtures/lodashBabelPlugin.jsx
+++ b/tests/babel/fixtures/lodashBabelPlugin.jsx
@@ -1,0 +1,18 @@
+// @flow
+
+import * as React from "react";
+import {intersection} from "lodash";
+
+(function() {
+  let a = 1;
+
+  // After hoisting, the hoisted function should be called with the transformed
+  // lodash import (i.e. `_intersection`)
+  const hoistable = (c, d) => {
+    // After hoisting, this should reference the `intersection` function param
+    intersection([], []);
+  };
+
+  // Use in JSXExpressionContainer to enable hoisting
+  <React.Component onClick={hoistable} />;
+})();

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -29,7 +29,7 @@ const SNAPSHOT_TRANSFORM_OPTS = {
   parserOpts: {
     plugins: ["flow", "jsx"],
   },
-  plugins: [TARGET_PLUGIN],
+  plugins: [TARGET_PLUGIN, "lodash"],
 };
 
 const VALIDATE_TRANSFORM_OPTS = {

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -147,6 +147,7 @@ const EVAL_RESULTS = {
   "fnWithFlow.jsx": 4,
   "ignorePropNameByRegex.jsx": undefined,
   "jsxHtmlLiteral.jsx": undefined,
+  "lodashBabelPlugin.jsx": undefined,
   "mapArrow.jsx": undefined,
   "noTransform.jsx": undefined,
   "reassignIdentifier.jsx": undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,20 @@
 # yarn lockfile v1
 
 
+"@babel/helper-module-imports@^7.0.0-beta.49":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0.tgz#6e191793d3c854d19c6749989e3bc55f0e962118"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -455,6 +469,16 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
+
+babel-plugin-lodash@3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0-beta.49"
+    "@babel/types" "^7.0.0-beta.49"
+    glob "^7.1.1"
+    lodash "^4.17.10"
+    require-package-name "^2.0.1"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -2386,6 +2410,10 @@ lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -2928,6 +2956,10 @@ require-directory@^2.1.1:
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
https://github.com/flexport/reflective-bind/issues/19

Fix hanging identifier when applying the lodash plugin after the reflective-bind plugin.

Without recrawling the scope at the end of the reflective-bind plugin, lodash would improperly transform references to lodash functions.

Without the recrawl, the transformed code looks like (notice the call to _testBBHoisted with `intersection` instead of `_intersection`):

```
import _intersection from \\"lodash/intersection\\";
// @flow

import { babelBind as _testBind } from \\"../../src\\";

function _testBBHoisted(intersection, c, d) {
// After hoisting, this should reference the \`intersection\` function param
intersection([], []);
}

import * as React from \\"react\\";

(function () {
let a = 1;

// After hoisting, the hoisted function should be called with the transformed
// lodash import (i.e. \`_intersection\`)
const hoistable = _testBind(_testBBHoisted, this, _intersection);

// Use in JSXExpressionContainer to enable hoisting
<React.Component onClick={hoistable} />;
})();
```