### PR TITLE
Handle non-computed object property identifiers

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -376,6 +376,7 @@ module.exports = function(opts) {
   function shouldHoistIdentifier(identifierPath, limitScope) {
     return (
       !isNonComputedNestedProperty(identifierPath) &&
+      !isNonComputedObjectKey(identifierPath) &&
       !hasBindingInScope(identifierPath, limitScope)
     );
   }
@@ -387,6 +388,15 @@ module.exports = function(opts) {
         t.isJSXMemberExpression(parentNode)) &&
       !parentNode.computed &&
       parentNode.property === identifierPath.node
+    );
+  }
+
+  function isNonComputedObjectKey(identifierPath) {
+    const parentNode = identifierPath.parentPath.node;
+    return (
+      t.isProperty(parentNode) &&
+      !parentNode.computed &&
+      parentNode.key === identifierPath.node
     );
   }
 

--- a/tests/babel/__snapshots__/index-test.js.snap
+++ b/tests/babel/__snapshots__/index-test.js.snap
@@ -350,6 +350,35 @@ import * as React from \\"react\\";
 })();"
 `;
 
+exports[`reflective-bind babel transform arrowObjectPropertyIdentifier.jsx 1`] = `
+"import { babelBind as _testBind } from \\"../../src\\";
+
+// @flow
+function _testBBHoisted(isParam) {
+  return {
+    // \`isParam\` should become a parameter in the hoisted function
+    [isParam]: 1,
+    // \`notParam\` should NOT become a parameter in the hoisted function
+    notParam: 2
+  };
+}
+
+import * as React from \\"react\\";
+
+class MyComponent extends React.Component {
+  render() {
+    const isParam = 1;
+    const notParam = 2;
+
+    const hoistable = _testBind(_testBBHoisted, this, isParam); // Use in JSXExpressionContainer to enable hoisting
+
+
+    return <React.Component onClick={hoistable} />;
+  }
+
+}"
+`;
+
 exports[`reflective-bind babel transform arrowRedeclareVar.jsx 1`] = `
 "import { babelBind as _testBind } from \\"../../src\\";
 

--- a/tests/babel/fixtures/arrowObjectPropertyIdentifier.jsx
+++ b/tests/babel/fixtures/arrowObjectPropertyIdentifier.jsx
@@ -1,0 +1,20 @@
+// @flow
+
+import * as React from "react";
+
+class MyComponent extends React.Component {
+  render() {
+    const isParam = 1;
+    const notParam = 2;
+
+    const hoistable = () => ({
+      // `isParam` should become a parameter in the hoisted function
+      [isParam]: 1,
+      // `notParam` should NOT become a parameter in the hoisted function
+      notParam: 2,
+    });
+
+    // Use in JSXExpressionContainer to enable hoisting
+    return <React.Component onClick={hoistable} />;
+  }
+}

--- a/tests/babel/index-test.js
+++ b/tests/babel/index-test.js
@@ -145,6 +145,7 @@ const EVAL_RESULTS = {
   "arrowNested.jsx": 10,
   "arrowNestedHoistDeep.jsx": undefined,
   "arrowNestedHoistInner.jsx": undefined,
+  "arrowObjectPropertyIdentifier.jsx": undefined,
   "arrowReferenceLateAssignment.jsx": 10,
   "arrowReferenceLateAssignmentDifferentScope.jsx": 10,
   "arrowReferenceOkAssignment.jsx": 10,


### PR DESCRIPTION
Fixes https://github.com/flexport/reflective-bind/issues/32

The transform was wastefully passing in any identifiers that had the same name as a non-computed object property in the hoisted function body.

This PR detects these cases and prevents these identifiers from becoming parameters in the hoisted function.

See the added test case for an example.